### PR TITLE
Draft of definitions box and collaborator roles box/table

### DIFF
--- a/content/box1.definitions.md
+++ b/content/box1.definitions.md
@@ -1,0 +1,32 @@
+<!--# I thought it might be helpful to have a box with short definitions of git/GitHub terminology used in the manuscript. If any of these are discussed more in depth in the main text, they may not need to be here. -->
+
+-   **repository**:
+
+-   **commit**: Commits are like snapshots in the development of a project.
+    Commits can include changes in multiple files and must include a brief commit message describing the changes made.
+    A typical workflow is to make some related changes in files, make a commit (e.g. "generate and include fig1 in results"), and after several commits to **push** those commits to the remote GitHub **repository**.
+
+-   clone: Cloning a **repository** is a way of making a local copy (i.e. on your computer) of a GitHub **repository**.
+    If you have access to **push** to a **repository**, this can be a first step to contributing to a project.
+
+-   branch: Development branches can be created at any point in time and work on each branch can continue independently.
+    This is useful for testing out new ideas (both code and text) which may or may not eventually get integrated into the main branch of the project.
+    Branches can also be used to isolate contributions of multiple contributors.
+    Each person working on their own branch eliminates problems that arise when conflicting edits are pushed to the same branch.
+    Changes in a development branch can be merged into the main branch via **pull requests**.
+    Branches can only be made by those who are given access to the project **repository**.
+
+-   fork: A fork is a copy of a **repository** hosted on GitHub.
+    If a repository is public, then anyone can make a fork.
+    Even if they do not have access to push to the original repository, they can make a fork and edit it independently.
+    Forks are linked to the original GitHub repository and "upstream" changes (those in the original repository) can be merged to keep the fork up to date with the original project.
+    Changes made in the fork can be integrated into the original project via **pull requests**.
+
+-   push/pull: When **commits** are made in a project locally, they must be synced with the remote GitHub repository by "**pushing**" them.
+    Changes on a GitHub repository can then be "**pulled**" to keep your local version of the project up to date.
+
+-   pull request: A pull request is a request that the owner of a GitHub repository integrate changes you've made on either a **branch** in the repository or in your own **fork**.
+    When you initiate a pull request, you must provide a description of what changes are made.
+    Some automated tests may be run and review may be required before integrating your changes.
+
+-   

--- a/content/box2.profiles.Rmd
+++ b/content/box2.profiles.Rmd
@@ -1,0 +1,32 @@
+---
+output: md_document
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = FALSE)
+```
+
+<!--# 
+This document is created from box2.profiles.Rmd, please made edits to code generating the table there.
+
+Edit the table contents here:https://docs.google.com/spreadsheets/d/1R0_NGhAWJ3cxGKQVh06eHKxHGMCN6x5aNL3_qR3nAI0/edit?usp=sharing 
+-->
+
+```{r include=FALSE}
+library(googlesheets4)
+library(tidyverse)
+library(knitr)
+library(pander)
+```
+
+```{r include=FALSE}
+df <- read_sheet("1R0_NGhAWJ3cxGKQVh06eHKxHGMCN6x5aNL3_qR3nAI0")
+```
+
+```{r results='asis'}
+set.alignment("left")
+df %>% 
+  replace_na(replace = list(Role = "", Description = "")) %>%
+  pander(split.table = 10000, caption = "Collaborator profiles and some example use cases for GitHub features.  This is a non-exhaustive list intended to showcase some creative uses of GitHub for collaborative academic projects, such as collaborative manuscript writing.")
+```
+

--- a/content/box2.profiles.md
+++ b/content/box2.profiles.md
@@ -1,0 +1,108 @@
+<!--# 
+This document is created from box2.profiles.Rmd, please made edits to code generating the table there.
+
+Edit the table contents here:https://docs.google.com/spreadsheets/d/1R0_NGhAWJ3cxGKQVh06eHKxHGMCN6x5aNL3_qR3nAI0/edit?usp=sharing 
+-->
+
+<table>
+<caption>Collaborator profiles and some example use cases for GitHub features. This is a non-exhaustive list intended to showcase some creative uses of GitHub for collaborative academic projects, such as collaborative manuscript writing.</caption>
+<colgroup>
+<col style="width: 18%" />
+<col style="width: 31%" />
+<col style="width: 18%" />
+<col style="width: 31%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th style="text-align: left;">Role</th>
+<th style="text-align: left;">Description</th>
+<th style="text-align: left;">GitHub Feature</th>
+<th style="text-align: left;">Use Case</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td style="text-align: left;">Project Manager</td>
+<td style="text-align: left;">Owner of the GitHub repository for a project. This is often, but not necessarily the main author of code and text for a manuscript or other academic project.</td>
+<td style="text-align: left;">Permissions</td>
+<td style="text-align: left;">The Project Manager can manage permissions of the repository to give push/pull access to contributors within their organization. They can protect the main branch from push access, if desired, to be sure all contributions are reviewed as pull requests.</td>
+</tr>
+<tr class="even">
+<td style="text-align: left;"></td>
+<td style="text-align: left;"></td>
+<td style="text-align: left;">Issues</td>
+<td style="text-align: left;">Project managers can use issues to track tasks and assign them to co-authors and code contributors. Tasks may including writing, code features, and responding to reviewer comments.</td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;"></td>
+<td style="text-align: left;"></td>
+<td style="text-align: left;">README</td>
+<td style="text-align: left;">The project README can contain contributor guidelines, a link to a project website (e.g. made with GitHub pages), and licence information.</td>
+</tr>
+<tr class="even">
+<td style="text-align: left;"></td>
+<td style="text-align: left;"></td>
+<td style="text-align: left;">Releases</td>
+<td style="text-align: left;">Releases mark milestones in the progression of a project (e.g. version of manuscript submitted to a journal). If a repository is linked to Zenodo, releases are automatically archived and given a unique DOI.</td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">Co-author</td>
+<td style="text-align: left;">Contributes writing, but has little to no experience with programming. Even if familiar with programming, they are unfamiliar with git and GitHub.</td>
+<td style="text-align: left;">GitHub Pages</td>
+<td style="text-align: left;">The Project Manager can use GitHub pages to share reports and figures with Co-Authors who can access up-to-date information through the project website.</td>
+</tr>
+<tr class="even">
+<td style="text-align: left;"></td>
+<td style="text-align: left;"></td>
+<td style="text-align: left;">Discussions</td>
+<td style="text-align: left;">Can be used as a forum to discuss proposed changes in a manuscript.</td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;"></td>
+<td style="text-align: left;"></td>
+<td style="text-align: left;">Markdown Editors</td>
+<td style="text-align: left;">Can contribute text as Markdown using a web interface through GitHub (Add File button) or through extensions like HackMD</td>
+</tr>
+<tr class="even">
+<td style="text-align: left;">Code contributor</td>
+<td style="text-align: left;">Anyone who contributes code to the project.</td>
+<td style="text-align: left;">Pull Requests</td>
+<td style="text-align: left;">Pull Requests are a natural way to contribute code to the project. These changes can be reviewed by the project manager or code reviewers before integrating them.</td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">Code reviewer</td>
+<td style="text-align: left;">Anyone asked to review project code (e.g. a co-author or a peer-reviewer). They are familiar with coding, but not necessarily with git or GitHub (but they are willing to learn).</td>
+<td style="text-align: left;">Issues</td>
+<td style="text-align: left;">Reviewers can highlight specific lines of code and create issues reffering to them with suggestions</td>
+</tr>
+<tr class="even">
+<td style="text-align: left;"></td>
+<td style="text-align: left;"></td>
+<td style="text-align: left;">Pull Requests</td>
+<td style="text-align: left;">Reviewers can either be assigned to review pull requests (e.g. from code contributors) or can make pull requests with recommended changes.</td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;">Community</td>
+<td style="text-align: left;">Anyone who wishes to use or adapt data or code for their own analysis</td>
+<td style="text-align: left;">Fork</td>
+<td style="text-align: left;">Anyone can use this feature to create a linked copy of the repository on their own GitHub account.</td>
+</tr>
+<tr class="even">
+<td style="text-align: left;"></td>
+<td style="text-align: left;"></td>
+<td style="text-align: left;">Discussions</td>
+<td style="text-align: left;">Community members can be directed to the Discussions tab as a place to ask clarifying questions about data and code.</td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;"></td>
+<td style="text-align: left;"></td>
+<td style="text-align: left;">GitHub Pages</td>
+<td style="text-align: left;">Can be used to create a public-facing website for the project that can be accessed by community members.</td>
+</tr>
+</tbody>
+</table>
+
+Collaborator profiles and some example use cases for GitHub features.
+This is a non-exhaustive list intended to showcase some creative uses of
+GitHub for collaborative academic projects, such as collaborative
+manuscript writing.


### PR DESCRIPTION
I created two "boxes".  One for definitions of git and GitHub terminology and another for the collaborator profiles idea I proposed.  Rather than editing a big markdown table, I thought it would be easier to host the table on Google Sheets.  I have a .Rmd file to pull the data and output a .md file with the formatted pandoc table.  I hope it works!