### PR TITLE
added new section that includes quick-links for important docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A friendly guide to GitHub and all the things you can **currently** do with it. 
 In this section you'll find a few important links to help us keep track of documents we use outside of the GitHub ecosystem.  This includes a google slide deck where we are working on figures, the original outline we made for the manuscript in HackMD, as well as meeting notes.
 
 **Links**
+[Figure brainstorming](https://docs.google.com/presentation/d/1SnAwK4XLlKf-XqGCqianW3-cGp3SlQYnCZ6ASJDKn_c/edit#slide=id.gf6fdd2a2d0_1_26)
 - [Figures for manuscript](https://docs.google.com/presentation/d/1b_8r7FHeVzP1tQ1H5mHVxw6xYU5A2KWCT3VbyrypWjs/edit?usp=sharing)
 - [Manuscript outline on HackMD](https://hackmd.io/@SORTEE-Github-Hackathon/Bki-SID8K)
 - Meeting notes from: [Jan 2022 (*including sign-up sheet for manuscript and figures*)](https://hackmd.io/@SORTEE-Github-Hackathon/S1KmI66TF), [Dec 2021](https://hackmd.io/@SORTEE-Github-Hackathon/r1nKg_CYK), [Oct 2021](https://hackmd.io/@SORTEE-Github-Hackathon/HkCsWuNLY), [Aug 2021](https://hackmd.io/@SORTEE-Github-Hackathon/H1NwRum4K)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ In this section you'll find a few important links to help us keep track of docum
 [Figure brainstorming](https://docs.google.com/presentation/d/1SnAwK4XLlKf-XqGCqianW3-cGp3SlQYnCZ6ASJDKn_c/edit#slide=id.gf6fdd2a2d0_1_26)
 - [Figures for manuscript](https://docs.google.com/presentation/d/1b_8r7FHeVzP1tQ1H5mHVxw6xYU5A2KWCT3VbyrypWjs/edit?usp=sharing)
 - [Manuscript outline on HackMD](https://hackmd.io/@SORTEE-Github-Hackathon/Bki-SID8K)
-- Meeting notes from: [Jan 2022 (*including sign-up sheet for manuscript and figures*)](https://hackmd.io/@SORTEE-Github-Hackathon/S1KmI66TF), [Dec 2021](https://hackmd.io/@SORTEE-Github-Hackathon/r1nKg_CYK), [Oct 2021](https://hackmd.io/@SORTEE-Github-Hackathon/HkCsWuNLY), [Aug 2021](https://hackmd.io/@SORTEE-Github-Hackathon/H1NwRum4K)
+- Meeting notes from: 
+  - [Jan 2022 (*including sign-up sheet for manuscript and figures*)](https://hackmd.io/@SORTEE-Github-Hackathon/S1KmI66TF), 
+  - [Dec 2021](https://hackmd.io/@SORTEE-Github-Hackathon/r1nKg_CYK), 
+  - [Oct 2021](https://hackmd.io/@SORTEE-Github-Hackathon/HkCsWuNLY), 
+  - [Aug 2021](https://hackmd.io/@SORTEE-Github-Hackathon/H1NwRum4K)
 
 **Dates**
 - **February 16, 2022**: first drafts of each section. Gather citations, high level overview of why topic is important.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,23 @@
 
 <!-- usage note: edit this section. -->
 
-A friendly guide to GitHub and all the things you can **currently** do with it. Very few papers focus on GitHub as a tool for collaboration. We will also mention where GitHub falls short as a tool for collaboration.
+A friendly guide to GitHub and all the things you can **currently** do with it. Very few papers focus on GitHub as a tool for collaboration. We will also mention where GitHub falls short as a tool for collaboration.  
+
+## Important links and dates
+In this section you'll find a few important links to help us keep track of documents we use outside of the GitHub ecosystem.  This includes a google slide deck where we are working on figures, the original outline we made for the manuscript in HackMD, as well as meeting notes.
+
+**Links**
+- [Figures for manuscript](https://docs.google.com/presentation/d/1b_8r7FHeVzP1tQ1H5mHVxw6xYU5A2KWCT3VbyrypWjs/edit?usp=sharing)
+- [Manuscript outline on HackMD](https://hackmd.io/@SORTEE-Github-Hackathon/Bki-SID8K)
+- Meeting notes from: [Jan 2022 (*including sign-up sheet for manuscript and figures*)](https://hackmd.io/@SORTEE-Github-Hackathon/S1KmI66TF), [Dec 2021](https://hackmd.io/@SORTEE-Github-Hackathon/r1nKg_CYK), [Oct 2021](https://hackmd.io/@SORTEE-Github-Hackathon/HkCsWuNLY), [Aug 2021](https://hackmd.io/@SORTEE-Github-Hackathon/H1NwRum4K)
+
+**Dates**
+- **February 16, 2022**: first drafts of each section. Gather citations, high level overview of why topic is important.
+- **February 23, 2022**: everyone does read through for general edits
+- **February 23, 2022**: figures and tables complete
+- **TBD**: Incorporate edits
+- **TBD**: Several authors do final detailed read through
+- **TBD**: Everyone approved before submission
 
 ## Contributing
 


### PR DESCRIPTION
In this PR, I include a new subsection to the README file that we discussed in our meeting today. As @LunaSare suggested, this will be important for capturing all of the documents that are outside of our GitHub ecosystem.

I included important quick-links to: google slides with our figures, hackmd of our manuscript outline, hackmd for each of our meeting notes.

I also include the project timeline that we discussed today.  Anything I am missing that we should link to?