### PR TITLE
added paragraph on github as lab notebook

### DIFF
--- a/content/03.use-cases-a.md
+++ b/content/03.use-cases-a.md
@@ -18,9 +18,13 @@ After linking your GitHub account to Zenodo and turning on archiving, any time a
 DOI's for data and code are increasingly being required by journals for paper acceptance (e.g., Journal of Applied Ecology), and Zenodo provides a free alternative to other fee-based hosting services (such as Dryad).
 
 ### Virtual lab notebook
-<!--*contributors to this section:* -->
-commits as a way to record daily progress
-issues as a way to keep track of short-term objectives/goals, and progress towards them
+<!--*contributors to this section: RCO* -->
+Lab notebooks have been indispensible tools for keeping track of research methods and laboratory policies [@doi:10.1186/s13321-017-0221-3].  
+Digital lab notebooks, stored in the cloud, provide clear benefits given the ease with which documents can be shared with new employees and updated as policy changes or experimental methods are modified [@doi:10.1371/journal.pcbi.1004385].  
+Increasingly, researchers are leveraging GitHub's underlying version control to keep and share digital lab notebooks [@doi:10.1038/538127a].  
+At a minimum, commit statements can provide a record of daily changes made to any code stored on GitHub [@doi:10.1186/1751-0473-8-7].  
+GitHub issues can be used to track and prioritize lab objectives and goals, as well as tracking any status updates.  
+Some EEB labs have even turned their lab notebooks into shareable websites [@url:https://scheuerell-lab.github.io/lab-book/; @url:https://github.com/HuckleyLab/how_we_work] as a centralized location for all lab resources.  
 
 ### Classroom teaching / educational materials
 <!-- *contributors to this section: Cole Brookson* -->


### PR DESCRIPTION
In this PR, I add text and citations related to how GitHub can be used as a lab notebook.

For two of these, I tried to include manubot citations built from web addresses as @Aariq suggested in our meeting today.