### PR TITLE
remove repetition about peer-review

### DIFF
--- a/content/04.use-cases-b.md
+++ b/content/04.use-cases-b.md
@@ -117,6 +117,8 @@ Other tools can also be used for version control of scientific manuscripts inclu
 <!--*contributors to this section:* Eric R. Scott-->
 
 Peer review of research software by rOpenSci (<https://ropensci.org/software-review/>) and of research software and associated manuscripts by the Journal of Open Source Software (<https://joss.readthedocs.io/en/latest/submitting.html>) requires that submitted work is hosted on GitHub and their review processes make use of GitHub issues.
+rOpenSci's efforts have resulted in many well-used R packages for ecology research including rfishbase [@doi:10.1111/j.1095-8649.2012.03464.x] and taxize [@doi:10.12688/F1000RESEARCH.2-191.V2].  
+
 GitHub can also be used as a hub for reviewers and authors during the peer review process of an ordinary research manuscript.
 If the code associated with a manuscript is made available at the time of submission (e.g. via a link to a GitHub repository in a Data Availability Statement), peer-reviewers may be able to offer more helpful suggestions on written methods and may even make comments on the code itself, potentially catching bugs or errors before publication <!--# would be nice to have an example to link to here.  I suspect it is rare that reviewers look at code, but it's happened to me (ERS) -->.
 GitHub issues can also be used to organize and discuss reviewer suggestions and to assign them to co-authors (See example in [@https://github.com/BrunaLab/HeliconiaDemography/issues?q=is%3Aissue+label%3A%22reviewer+comment%22+].

--- a/content/05.use-cases-c.md
+++ b/content/05.use-cases-c.md
@@ -81,10 +81,6 @@ First, there are increasing calls for ecological data to be more Findable, Acces
 A key component of data reusability is standardizing the ways (e.g., variable names, file formats) that research data are archived in long-term repositories.
 Recently, community-led data standardization efforts are taking place on GitHub [@doi:10.1029/2021EA001797], where documents and templates can be version controlled and commented on by the user community (e.g., ESS-DIVE's GitHub Community Space, [@https://github.com/ess-dive-community]).  
 
-Ecologists who write code often use the R programming language, and the rOpenSci [@https://ropensci.org/] community has a well-established software peer review process that involves both rOpenSci's staff software engineers and the broader R user community.
-Their software review GitHub repository [@https://github.com/ropensci/software-review/] provides instructions for submitting an R package for review as well as guidelines for code reviewers.
-rOpenSci's efforts have resulted in many well-used R packages for ecology research including rfishbase [@doi:10.1111/j.1095-8649.2012.03464.x] and taxize [@doi:10.12688/F1000RESEARCH.2-191.V2].  
-
 Lastly, GitHub gists let users create and share snippets of code, notes, and files quickly.
 Rather than create an entire GitHub repository for saving a small code chunk you want to use in a presentation or share with a colleague, GitHub gists provide a lightweight way to write, save, and share code.
 Gists are associated with your Github account and can be public or private.


### PR DESCRIPTION
In response to a comment in hypothesis I have deleted the section in "Additional uses for GitHub in EcoEvo research" and moved some text to the Peer Review section