### PR TITLE
Remove duplicate author in yaml file

### DIFF
--- a/content/metadata.yaml
+++ b/content/metadata.yaml
@@ -30,13 +30,6 @@ authors:
     twitter: hebert_kat
     affiliations:
       - Département de biologie, Université de Sherbrooke, Québec, Canada
-  - github: fhillemann
-    name: Friederike Hillemann
-    initials: FH
-    orcid: 0000-0002-8992-0676
-    email: f.hillemann@web.de
-    affiliations:
-      - Department of Human Behavior, Ecology and Culture, Max Planck Institute for Evolutionary Anthropology, Leipzig, Germany
   - github: emmajhudgins
     name: Emma J. Hudgins
     initials: EJH


### PR DESCRIPTION
In this PR I remove author who was accidentally included twice on our list. Closes #220  Thanks for catching this @Aguncan 