### PR TITLE
correct file name in Render step of the Rendering Editorial Communication Material workflow

### DIFF
--- a/.github/workflows/editorial-comm-render-build-deploy.yaml
+++ b/.github/workflows/editorial-comm-render-build-deploy.yaml
@@ -47,7 +47,7 @@ jobs:
         run: Rscript -e 'rmarkdown::render("cover-letter-submission.Rmd")'
         
       - name: 🧶 Render
-        run: Rscript -e 'rmarkdown::render("response-to-reviewers.Rmd")'
+        run: Rscript -e 'rmarkdown::render("response-to-the-reviewers.Rmd")'
         
       - name: 🔺 Upload artifact containing the letter
         uses: actions/upload-artifact@v1


### PR DESCRIPTION
The Rendering Editorial Communication Material workflow seems to be failing because it cannot find the Rmd for the response to the reviewers (the name doesn't match!)