### PR TITLE
Some weird formatting

### DIFF
--- a/content/03.use-cases-a.md
+++ b/content/03.use-cases-a.md
@@ -47,7 +47,7 @@ Github Issues allow for discrete tasks and sub-tasks to be identified, assigned 
 Github Discussions serve as a message board for conversation.
 Finally, GitHub Projects provides users with real-time tracking of project priorities and status [@url:https://docs.github.com/en/issues/trying-out-the-new-projects-experience/about-projects].
 For instance, one can create a discussion on a project repository to decide which method to apply for biodiversity data analysis.
-Then, an issue can be created to establish steps and responsibilities including data formatting, statistical analyses, figure generation, and issue resolution [_e.g._, see issues and discussions in the sPlotOpen manuscript repository, @doi:10.1111/geb.13346]; @url:https://github.com/fmsabatini/sPlotOpen_Manuscript/issues?q=is%3Aissue+is%3Aclosed].
+Then, an issue can be created to establish steps and responsibilities including data formatting, statistical analyses, figure generation, and issue resolution [_e.g._, see issues and discussions in the sPlotOpen manuscript repository, @doi:10.1111/geb.13346; @url:https://github.com/fmsabatini/sPlotOpen_Manuscript/issues?q=is%3Aissue+is%3Aclosed].
 Using GitHub for all project-related conversation and planning, rather than email or messaging tools, makes it easier to keep track of progress throughout the lifespan of a project. 
 However, one can opt to receive new issues, discussions, and responses as emails and can post replies by email as well.  
 This allows for centralized communication for a team even when some members prefer to use email for communication.

--- a/content/04.use-cases-b.md
+++ b/content/04.use-cases-b.md
@@ -5,7 +5,7 @@
 <!--*Contributors to this section: Rob Crystal-Ornelas, Emma Hudgins*   -->
 Personal or laboratory websites can improve the sharing of research findings, build online presence, and increase coordination of research efforts [@doi:10.1038/nj7142-347a].
 Despite researchers in ecology and evolution generally lacking experience in building or hosting webpages, many tools have been developed to help this process.
-Static websites can now be easily built [using, for example Quarto (<https://quarto.org>), RMarkdown, Hugo (<https://gohugo.io>), GitHub Website templates (<https://github.com/topics/website-template>))], stored in a repository, and be readily hosted by activating GitHub's Pages (<https://pages.github.com>) feature.
+Static websites can now be easily built [using, for example Quarto (<https://quarto.org>), RMarkdown, Hugo (<https://gohugo.io>), GitHub Website templates (<https://github.com/topics/website-template>)), stored in a repository, and be readily hosted by activating GitHub's Pages (<https://pages.github.com>) feature.
 Creating and hosting websites on GitHub Pages is more complex than out-of-the-box platforms (_e.g._, Wix, Weebly, Google Sites).
 However, free hosting, widely available template customization, and versioning are strong advantages over alternatives.
 
@@ -81,4 +81,4 @@ Co-authors can then integrate their edits and responses to reviewers using pull 
 
 GitHub can also assist reviewers during the peer review process.
 If the code associated with a manuscript is made available at the time of submission (_e.g._, as a link to a GitHub repository within the Data Availability Statement), peer reviewers may be able to offer more comprehensive suggestions on the code and written materials, potentially recognizing errors before publication.
-Certain journals or software development communities require submitted work or research code to be hosted on GitHub and their review processes make use of GitHub Issues (_e.g._, rOpenSci (<https://ropensci.org/software-review/>), Journal of Open Source Software (<https://joss.readthedocs.io/en/latest/submitting.html>)).
+Certain journals or software development communities require submitted work or research code to be hosted on GitHub and their review processes make use of GitHub Issues (_e.g._, rOpenSci (<https://ropensci.org/software-review/>), Journal of Open Source Software (<https://joss.readthedocs.io/en/latest/submitting.html>).

--- a/content/06.discussion-a.md
+++ b/content/06.discussion-a.md
@@ -50,9 +50,9 @@ However, we emphasize that there are opportunities for collaboration using GitHu
 A third barrier may come from general reluctance to share data and code publicly, or technical and logistical issues [@doi:10.31222/osf.io/gaj43].
 GitHub is, by default, a public and open platform.
 This openness may add additional pressure to students and scientists learning to use the platform.
-Moreover, additional tools may be required to fully integrate project files and GitHub repositories (_e.g._, [@url:https://help.osf.io/article/211-connect-github-to-a-project]).
+Moreover, additional tools may be required to fully integrate project files and GitHub repositories [_e.g._, @url:https://help.osf.io/article/211-connect-github-to-a-project].
 Other scientists may simply lack the time or incentives to document and version control their code if the code is unlikely to be reused beyond their analysis.
-However we (and others, _e.g.,_ [@doi:10.1098/rspb.2022.1113]) argue that the endeavour of open science and collaboration requires code owners to document and version control code despite uncertainty around future use.
+However we [and others, _e.g.,_ @doi:10.1098/rspb.2022.1113] argue that the endeavour of open science and collaboration requires code owners to document and version control code despite uncertainty around future use.
 
 A fourth additional barrier to EEB researchers is the lack language-specific resources for non-English speaking researchers working in ecology and evolution.
 Language is a well-known obstacle to international collaborative research progress and to widespread scientific knowledge [see @doi:10.1016/j.tree.2021.11.003].


### PR DESCRIPTION
There were some strange formatting things happening - I think I have solved most but some are still a mystery to me. In 04.use-cases-a.md under the heading "Archiving citable code and data" there is a section which renders strangly - line 26.  

`This strategy has been increasingly adopted in numerous studies in ecology and evolution (_e.g._, the Zenodo repositores for @doi:10.5281/zenodo.6097109, @doi:10.5281/zenodo.3893943, and @doi:10.5281/zenodo.1188710)`

`This strategy has been increasingly adopted in numerous studies in ecology and evolution (e.g., the Zenodo repositores for Hudgins ([2022](https://sortee-github-hackathon.github.io/manuscript/v/latest/index.html#ref-GQj3c17f)), EllenJCoombs ([2020](https://sortee-github-hackathon.github.io/manuscript/v/latest/index.html#ref-bZNn2hbh)), and Lrharper1 ([2018](https://sortee-github-hackathon.github.io/manuscript/v/latest/index.html#ref-ZI1OqZNr))).`

Should these be upper case "LR Harper" and have spaces "Ellen J Coombs" or is there nothing we can do about this because it is reading from the Zenodo format?