### PR TITLE
Add DOI badges and citation info

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,97 @@
+# -----------------------------------------------------------
+# CITATION file created with {cffr} R package, v0.4.1
+# See also: https://docs.ropensci.org/cffr/
+# -----------------------------------------------------------
+ 
+cff-version: 1.2.0
+message: "If you use the code in this repository in a publication, please cite the published paper"
+type: software
+title: "Code repository for 'Not Just for Programmers: How GitHub Can Accelerate Collaborative and Reproducible Research in Ecology and Evolution'"
+doi: 10.17605/OSF.IO/BYPFM
+authors: 
+  - family-names: Braga
+    given-names: Pedro Henrique Pereira
+  - family-names: Hébert
+    given-names: Katherine
+  - family-names: Hudgins
+    given-names: Emma J.
+  - family-names: Scott
+    given-names: Eric R.
+  - family-names: Edwards
+    given-names: Brandon P. M.
+  - family-names: Sánchez Reyes
+    given-names: Luna L.
+  - family-names: Grainger
+    given-names: Matthew J.
+  - family-names: Foroughirad
+    given-names: Vivienne
+  - family-names: Hillemann
+    given-names: Friederike
+  - family-names: Binley
+    given-names: Allison D.
+  - family-names: Brookson
+    given-names: Cole B.
+  - family-names: Gaynor
+    given-names: Kaitlyn M.
+  - family-names: Shafiei Sabet
+    given-names: Saeed
+  - family-names: Güncan
+    given-names: Ali
+  - family-names: Weierbach
+    given-names: Helen
+  - family-names: Gomes
+    given-names: Dylan G. E.
+  - family-names: Crystal-Ornelas
+    given-names: Robert
+
+preferred-citation:
+  type: article
+  title: 'Not Just for Programmers: How GitHub Can Accelerate Collaborative and Reproducible Research in Ecology and Evolution'
+  doi: 10.1111/2041-210X.14108
+  url: https://besjournals.onlinelibrary.wiley.com/doi/abs/10.1111/2041-210X.14108
+  authors:
+    - family-names: Braga
+      given-names: Pedro Henrique Pereira
+    - family-names: Hébert
+      given-names: Katherine
+    - family-names: Hudgins
+      given-names: Emma J.
+    - family-names: Scott
+      given-names: Eric R.
+    - family-names: Edwards
+      given-names: Brandon P. M.
+    - family-names: Sánchez Reyes
+      given-names: Luna L.
+    - family-names: Grainger
+      given-names: Matthew J.
+    - family-names: Foroughirad
+      given-names: Vivienne
+    - family-names: Hillemann
+      given-names: Friederike
+    - family-names: Binley
+      given-names: Allison D.
+    - family-names: Brookson
+      given-names: Cole B.
+    - family-names: Gaynor
+      given-names: Kaitlyn M.
+    - family-names: Shafiei Sabet
+      given-names: Saeed
+    - family-names: Güncan
+      given-names: Ali
+    - family-names: Weierbach
+      given-names: Helen
+    - family-names: Gomes
+      given-names: Dylan G. E.
+    - family-names: Crystal-Ornelas
+      given-names: Robert
+  year: 2023
+  journal: "Methods in Ecology and Evolution"
+  keywords:
+    - collaboration
+    - data management
+    - ecoinformatics
+    - GitHub
+    - open science
+    - project management
+    - reproducible research
+    - version control

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![GitHub Actions Status](https://github.com/SORTEE-Github-Hackathon/manuscript/actions/workflows/manubot.yaml/badge.svg)](https://github.com/SORTEE-Github-Hackathon/manuscript/actions/workflows/manubot.yaml)
 [![DOI](https://img.shields.io/badge/DOI-10.1111%2F2041--210X.14108-blue)](https://doi.org/10.1111/2041-210X.14108)
 [![Preprint](https://img.shields.io/badge/preprint-10.31222%2Fosf.io%2Fx3p2q-blue)](https://doi.org/10.31222/osf.io/x3p2q)
-[![code archive](https://img.shields.io/badge/code-10.17605%2FOSF.IO%2FBYPFM-blue)](https://doi.org/10.17605/OSF.IO/BYPFM)
+[![Code Archive](https://img.shields.io/badge/code-10.17605%2FOSF.IO%2FBYPFM-blue)](https://doi.org/10.17605/OSF.IO/BYPFM)
 
 If you use the code in this repository in a publication, please cite the published paper:
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 [![HTML Manuscript](https://img.shields.io/badge/manuscript-HTML-blue.svg)](https://sortee-github-hackathon.github.io/manuscript/v/latest/index.html)
 [![PDF Manuscript](https://img.shields.io/badge/manuscript-PDF-blue.svg)](https://SORTEE-Github-Hackathon.github.io/manuscript/v/latest/manuscript.pdf)
 [![GitHub Actions Status](https://github.com/SORTEE-Github-Hackathon/manuscript/actions/workflows/manubot.yaml/badge.svg)](https://github.com/SORTEE-Github-Hackathon/manuscript/actions/workflows/manubot.yaml)
+[![DOI](https://img.shields.io/badge/DOI-10.1111%2F2041--210X.14108-blue)](https://doi.org/10.1111/2041-210X.14108)
+[![Preprint](https://img.shields.io/badge/preprint-10.31222%2Fosf.io%2Fx3p2q-blue)](https://doi.org/10.31222/osf.io/x3p2q)
+[![code archive](https://img.shields.io/badge/code-10.17605%2FOSF.IO%2FBYPFM-blue)](https://doi.org/10.17605/OSF.IO/BYPFM)
 
 ### Subject: The use of Github in Ecology and Evolution
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,27 @@
 [![Preprint](https://img.shields.io/badge/preprint-10.31222%2Fosf.io%2Fx3p2q-blue)](https://doi.org/10.31222/osf.io/x3p2q)
 [![code archive](https://img.shields.io/badge/code-10.17605%2FOSF.IO%2FBYPFM-blue)](https://doi.org/10.17605/OSF.IO/BYPFM)
 
+If you use the code in this repository in a publication, please cite the published paper:
+
+Braga, P.H.P., Hébert, K., Hudgins, E.J., Scott, E.R., Edwards, B.P.M., Sánchez Reyes, L.L., Grainger, M.J., Foroughirad, V., Hillemann, F., Binley, A.D., Brookson, C.B., Gaynor, K.M., Shafiei Sabet, S., Güncan, A., Weierbach, H., Gomes, D.G.E., Crystal-Ornelas, R., 2023. Not just for programmers: How GitHub can accelerate collaborative and reproducible research in ecology and evolution. Methods in Ecology and Evolution n/a. https://doi.org/10.1111/2041-210X.14108
+
+BibTeX entry:
+
+```
+@article{bragaNotJustProgrammers2023,
+  title = {Not Just for Programmers: {{How GitHub}} Can Accelerate Collaborative and Reproducible Research in Ecology and Evolution},
+  author = {Braga, Pedro Henrique Pereira and H{\'e}bert, Katherine and Hudgins, Emma J. and Scott, Eric R. and Edwards, Brandon P. M. and S{\'a}nchez Reyes, Luna L. and Grainger, Matthew J. and Foroughirad, Vivienne and Hillemann, Friederike and Binley, Allison D. and Brookson, Cole B. and Gaynor, Kaitlyn M. and Shafiei Sabet, Saeed and G{\"u}ncan, Ali and Weierbach, Helen and Gomes, Dylan G. E. and {Crystal-Ornelas}, Robert},
+  year = {2023},
+  journal = {Methods in Ecology and Evolution},
+  volume = {n/a},
+  number = {n/a},
+  doi = {10.1111/2041-210X.14108},
+  copyright = {All rights reserved},
+  langid = {english},
+  keywords = {collaboration,data management,ecoinformatics,GitHub,open science,project management,reproducible research,version control},
+}
+```
+
 ### Subject: The use of Github in Ecology and Evolution
 
 ## Manuscript description


### PR DESCRIPTION
Adds DOI badges for the archived code repository, the pre-print, and the published paper.  Also adds citation information to README.md and adds a CITATION.cff file with a preferred citation of the published paper.  The CITATION.cff file is parsed by GitHub to make citing our project easier.